### PR TITLE
remove outdated starter

### DIFF
--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -48,7 +48,6 @@ hilla-quickstart-tutorial
 hilla-basics-tutorial
 flow-quickstart-tutorial
 addon-template
-addon-starter-flow
 npm-addon-template
 client-server-addon-template
 spreadsheet-demo


### PR DESCRIPTION
addon-starter-flow has been renamed to addon-template, so there is no need to list both