### PR TITLE
fix identity manager Visual tests and add to the list

### DIFF
--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -1,5 +1,5 @@
 const { expect} = require('@playwright/test');
-const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
+const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, err} = require('./test-utils');
 
 (async () => {
     const arg = args();
@@ -94,23 +94,26 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await closePage(pageApp);
 
     log('Cleaning up...\n');
-    await page.getByRole('link', { name: 'Roles' }).click();
-    await page.getByText('admin').nth(1).click();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Delete' }).nth(0).click();
-    await page.getByRole('link', { name: 'Groups' }).click();
-    await page.getByText('admin', { exact: true }).click();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Delete' }).nth(0).click();
-    await page.getByRole('link', { name: 'Users' }).click();
-    await page.getByText('admin user').click();
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Delete' }).nth(0).click();
-    await page.getByRole('link', { name: 'Settings' }).click();
-    await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
-    await page.getByLabel('Identity Management').uncheck();
-    await page.getByRole('button', { name: 'Disable' }).click();
-    await page.getByRole('button', { name: 'Update' }).click();
-
+    try {
+        await page.getByRole('link', { name: 'Roles' }).click();
+        await page.getByText('admin').nth(1).click();
+        await page.getByRole('button', { name: 'Delete' }).click();
+        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.getByRole('link', { name: 'Groups' }).click();
+        await page.getByText('admin', { exact: true }).click();
+        await page.getByRole('button', { name: 'Delete' }).click();
+        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.getByRole('link', { name: 'Users' }).click();
+        await page.getByText('admin user').click();
+        await page.getByRole('button', { name: 'Delete' }).click();
+        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.getByRole('link', { name: 'Settings' }).click();
+        await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
+        await page.getByLabel('Identity Management').uncheck();
+        await page.getByRole('button', { name: 'Disable' }).click();
+        await page.getByRole('button', { name: 'Update' }).click();
+    } catch (error) {
+        err(`Error cleaning up: ${error}\n`);
+    }
     await closePage(page);
 })();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -1,7 +1,5 @@
 const { expect} = require('@playwright/test');
-const fs = require('fs');
 const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
-
 
 (async () => {
     const arg = args();
@@ -23,7 +21,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await expect(page.getByLabel('Email')).toBeVisible();
     await takeScreenshot(page, __filename, 'view-loaded');
 
-    log(`Logging in as ${arg.login} ${arg.pass}...\n`);
+    log(`Logging in CC as ${arg.login} ${arg.pass}...\n`);
     await page.getByLabel('Email').fill(arg.login);
     await page.getByLabel('Password').fill(arg.pass);
     await page.getByRole('button', {name: 'Sign In'}).click()
@@ -35,11 +33,10 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     log(`App: ${app} installed in: ${url}\n`);
 
     await page.locator('vaadin-select vaadin-input-container div').click();
-    await page.getByRole('option', { name: 'bakery-cc' }).locator('div').nth(2).click();
+    await page.getByRole('option', { name: app }).locator('div').nth(2).click();
     await takeScreenshot(page, __filename, 'selected-app');
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await page.getByRole('button', { name: 'Enable Identity Management' }).click();
-    await takeScreenshot(page, __filename, 'app-updated');
     await takeScreenshot(page, __filename, 'enabled');
 
     await page.getByRole('link', { name: 'Roles' }).click();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -34,7 +34,7 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
 
     log(`Checking that  ${app} installed in ${url} is running ...\n`);
     // When app is not running, localization cannot be enabled
-    let pageApp = await createPage(arg.headless, true);
+    let pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
     await waitForServerReady(pageApp, url);
     await takeScreenshot(pageApp, __filename, 'app-running');
     await closePage(pageApp);
@@ -83,7 +83,7 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     await takeScreenshot(page, __filename, 'user-created');
 
     log(`Logging in ${app} as ${user} ...\n`);
-    pageApp = await createPage(arg.headless, true);
+    pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
     await waitForServerReady(pageApp, url);
     await takeScreenshot(pageApp, __filename, `app-${app}-loaded`);
     await pageApp.getByLabel('Email').fill(user);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -36,8 +36,8 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, err
     // When app is not running, localization cannot be enabled
     let pageApp = await createPage(arg.headless, true);
     await waitForServerReady(pageApp, url);
+    await takeScreenshot(pageApp, __filename, 'app-running');
     await closePage(pageApp);
-    await takeScreenshot(page, __filename, 'app-running');
 
     log(`Enabling identity Management ...\n`);
     await page.locator('vaadin-select vaadin-input-container div').click();
@@ -114,6 +114,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, err
         await page.getByRole('button', { name: 'Update' }).click();
     } catch (error) {
         err(`Error cleaning up: ${error}\n`);
+        await takeScreenshot(page, __filename, 'error-cleaning');
     }
     await closePage(page);
 })();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -45,6 +45,7 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     await takeScreenshot(page, __filename, 'selected-app');
 
     await page.getByRole('link', { name: 'Identity Management' }).click();
+    await takeScreenshot(page, __filename, 'identity-link-clicked');
     await page.getByRole('button', { name: 'Enable Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-enabled');
 

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -72,7 +72,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await page.getByRole('contentinfo').getByRole('button', { name: 'Create' }).click();
     await takeScreenshot(page, __filename, 'user-created');
 
-    await page.goto(url);
+    await waitForServerReady(page, url);
     await takeScreenshot(page, __filename, `app-${app}-loaded`);
 
     log(`Logging in ${app} as ${user} ...\n`);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -40,11 +40,10 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await page.getByRole('button', { name: 'Enable Identity Management' }).click();
     await takeScreenshot(page, __filename, 'app-updated');
-    await takeScreenshot(page, __filename, 'enabled');
+    await takeScreenshot(page, __filename, 'identity-management-enabled');
 
     await page.getByRole('link', { name: 'Roles' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
-    await takeScreenshot(page, __filename, 'role-form');
     await page.getByLabel('Name').fill(role);
     await page.getByLabel('Description').fill(role);
     await takeScreenshot(page, __filename, 'role-filled');
@@ -53,7 +52,6 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
 
     await page.getByRole('link', { name: 'Groups' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
-    await takeScreenshot(page, __filename, 'group-form');
     await page.getByLabel('Name').fill(group);
     await page.locator(checkboxSelectorRole).click();
     await takeScreenshot(page, __filename, 'group-filled');
@@ -62,7 +60,6 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
 
     await page.getByRole('link', { name: 'Users' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
-    await takeScreenshot(page, __filename, 'user-form');
     await page.getByLabel('First Name').fill(role);
     await page.getByLabel('Last Name').fill('user');
     await page.getByLabel('E-mail Address').fill(user);
@@ -72,7 +69,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await page.getByRole('contentinfo').getByRole('button', { name: 'Create' }).click();
     await takeScreenshot(page, __filename, 'user-created');
 
-    await waitForServerReady(page, url);
+    await page.goto(url);
     await takeScreenshot(page, __filename, `app-${app}-loaded`);
 
     log(`Logging in ${app} as ${user} ...\n`);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -96,18 +96,22 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     log('Cleaning up...\n');
     try {
         await page.getByRole('link', { name: 'Roles' }).click();
-        await page.getByText('admin').nth(1).click();
+        await page.waitForTimeout(2000);
+        await page.getByText(role, { exact: true }).nth(1).click();
         await page.getByRole('button', { name: 'Delete' }).click();
-        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.locator('vaadin-confirm-dialog-overlay').getByRole('button', { name: 'Delete' }).click();
         await page.getByRole('link', { name: 'Groups' }).click();
-        await page.getByText('admin', { exact: true }).click();
+        await page.waitForTimeout(2000);
+        await page.getByText(group, { exact: true }).click();
         await page.getByRole('button', { name: 'Delete' }).click();
-        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.locator('vaadin-confirm-dialog-overlay').getByRole('button', { name: 'Delete' }).click();
         await page.getByRole('link', { name: 'Users' }).click();
-        await page.getByText('admin user').click();
+        await page.waitForTimeout(2000);
+        await page.getByText(user, { exact: true }).click();
         await page.getByRole('button', { name: 'Delete' }).click();
-        await page.getByRole('button', { name: 'Delete' }).nth(0).click();
+        await page.locator('vaadin-confirm-dialog-overlay').getByRole('button', { name: 'Delete' }).click();
         await page.getByRole('link', { name: 'Settings' }).click();
+        await page.waitForTimeout(2000);
         await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
         await page.getByLabel('Identity Management').uncheck();
         await page.getByRole('button', { name: 'Disable' }).click();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -47,7 +47,14 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     // Button is enabled after app is running, let's see
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-link-clicked');
-    await page.getByRole('button', { name: 'Enable Identity Management' }).click();
+    try {
+        await page.getByRole('button', { name: 'Enable Identity Management' }).click();
+    } catch (error) {
+        err(`Retrying in 60 secs looking for enabled button : ${error}\n`);
+        await page.waitForTimeout(60000);
+        await page.reload();
+        await page.getByRole('button', { name: 'Enable Identity Management' }).click();
+    }
     await takeScreenshot(page, __filename, 'identity-enabled');
 
     log(`Adding Role, Group and User ...\n`);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -34,7 +34,6 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
 
     log(`Checking that  ${app} installed in ${url} is running ...\n`);
 
-    log(`Enabling identity Management ...\n`);
     await page.locator('vaadin-select vaadin-input-container div').click();
     await page.getByRole('option', { name: app }).locator('div').nth(2).click();
     await takeScreenshot(page, __filename, 'selected-app');
@@ -45,15 +44,29 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     await takeScreenshot(pageApp, __filename, 'app-running');
     await closePage(pageApp);
     // Button is enabled after app is running, let's see
+    log(`Enabling identity Management ...\n`);
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-link-clicked');
     try {
+        await page.waitForTimeout(2000);
         await page.getByRole('button', { name: 'Enable Identity Management' }).click();
     } catch (error) {
-        err(`Retrying in 60 secs looking for enabled button : ${error}\n`);
-        await page.waitForTimeout(60000);
-        await page.reload();
-        await page.getByRole('button', { name: 'Enable Identity Management' }).click();
+        try {
+            await page.getByRole('link', { name: 'Settings' }).click();
+            await page.waitForTimeout(2000);
+            await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
+            await page.getByLabel('Identity Management').check();
+            await page.getByRole('button', { name: 'Update' }).click();
+            await page.locator('vaadin-select vaadin-input-container div').click();
+            await page.getByRole('option', { name: app }).locator('div').nth(2).click();
+            await page.getByRole('link', { name: 'Identity Management' }).click();
+        } catch (error) {
+            err(`Retrying in 60 secs looking for enabled button : ${error}\n`);
+            await page.waitForTimeout(60000);
+            await page.reload();
+            await page.getByRole('link', { name: 'Identity Management' }).click();
+            await page.getByRole('button', { name: 'Enable Identity Management' }).click();
+        }
     }
     await takeScreenshot(page, __filename, 'identity-enabled');
 

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -41,33 +41,14 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     // When app is not running, localization button might not be enabled
     let pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
     await waitForServerReady(pageApp, url);
-    await takeScreenshot(pageApp, __filename, 'app-running');
+    await takeScreenshot(pageApp, __filename, `app-${app}-running`);
     await closePage(pageApp);
     // Button is enabled after app is running, let's see
     log(`Enabling identity Management ...\n`);
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-link-clicked');
-    try {
-        await page.waitForTimeout(2000);
-        await page.getByRole('button', { name: 'Enable Identity Management' }).click();
-    } catch (error) {
-        try {
-            await page.getByRole('link', { name: 'Settings' }).click();
-            await page.waitForTimeout(2000);
-            await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
-            await page.getByLabel('Identity Management').check();
-            await page.getByRole('button', { name: 'Update' }).click();
-            await page.locator('vaadin-select vaadin-input-container div').click();
-            await page.getByRole('option', { name: app }).locator('div').nth(2).click();
-            await page.getByRole('link', { name: 'Identity Management' }).click();
-        } catch (error) {
-            err(`Retrying in 60 secs looking for enabled button : ${error}\n`);
-            await page.waitForTimeout(60000);
-            await page.reload();
-            await page.getByRole('link', { name: 'Identity Management' }).click();
-            await page.getByRole('button', { name: 'Enable Identity Management' }).click();
-        }
-    }
+    await page.waitForTimeout(2000);
+    await page.getByRole('button', { name: 'Enable Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-enabled');
 
     log(`Adding Role, Group and User ...\n`);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -1,5 +1,5 @@
 const { expect} = require('@playwright/test');
-const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, err} = require('./test-utils');
+const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
 
 (async () => {
     const arg = args();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -40,10 +40,11 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await page.getByRole('button', { name: 'Enable Identity Management' }).click();
     await takeScreenshot(page, __filename, 'app-updated');
-    await takeScreenshot(page, __filename, 'identity-management-enabled');
+    await takeScreenshot(page, __filename, 'enabled');
 
     await page.getByRole('link', { name: 'Roles' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
+    await takeScreenshot(page, __filename, 'role-form');
     await page.getByLabel('Name').fill(role);
     await page.getByLabel('Description').fill(role);
     await takeScreenshot(page, __filename, 'role-filled');
@@ -52,6 +53,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
 
     await page.getByRole('link', { name: 'Groups' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
+    await takeScreenshot(page, __filename, 'group-form');
     await page.getByLabel('Name').fill(group);
     await page.locator(checkboxSelectorRole).click();
     await takeScreenshot(page, __filename, 'group-filled');
@@ -60,6 +62,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
 
     await page.getByRole('link', { name: 'Users' }).click();
     await page.getByRole('button', { name: 'Create' }).click();
+    await takeScreenshot(page, __filename, 'user-form');
     await page.getByLabel('First Name').fill(role);
     await page.getByLabel('Last Name').fill('user');
     await page.getByLabel('E-mail Address').fill(user);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -50,6 +50,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
 
     log(`Adding Role, Group and User ...\n`);
     await page.getByRole('link', { name: 'Roles' }).click();
+    await page.waitForTimeout(2000);
     await page.getByRole('button', { name: 'Create' }).click();
     await takeScreenshot(page, __filename, 'role-form');
     await page.getByLabel('Name').fill(role);
@@ -59,6 +60,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await takeScreenshot(page, __filename, 'role-created');
 
     await page.getByRole('link', { name: 'Groups' }).click();
+    await page.waitForTimeout(2000);
     await page.getByRole('button', { name: 'Create' }).click();
     await takeScreenshot(page, __filename, 'group-form');
     await page.getByLabel('Name').fill(group);
@@ -68,6 +70,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await takeScreenshot(page, __filename, 'group-created');
 
     await page.getByRole('link', { name: 'Users' }).click();
+    await page.waitForTimeout(2000);
     await page.getByRole('button', { name: 'Create' }).click();
     await takeScreenshot(page, __filename, 'user-form');
     await page.getByLabel('First Name').fill(role);

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -33,17 +33,18 @@ const {log, err, args, createPage, closePage, takeScreenshot, waitForServerReady
     const url = await page.locator(anchorSelectorURL).getAttribute('href');
 
     log(`Checking that  ${app} installed in ${url} is running ...\n`);
-    // When app is not running, localization cannot be enabled
-    let pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
-    await waitForServerReady(pageApp, url);
-    await takeScreenshot(pageApp, __filename, 'app-running');
-    await closePage(pageApp);
 
     log(`Enabling identity Management ...\n`);
     await page.locator('vaadin-select vaadin-input-container div').click();
     await page.getByRole('option', { name: app }).locator('div').nth(2).click();
     await takeScreenshot(page, __filename, 'selected-app');
 
+    // When app is not running, localization button might not be enabled
+    let pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
+    await waitForServerReady(pageApp, url);
+    await takeScreenshot(pageApp, __filename, 'app-running');
+    await closePage(pageApp);
+    // Button is enabled after app is running, let's see
     await page.getByRole('link', { name: 'Identity Management' }).click();
     await takeScreenshot(page, __filename, 'identity-link-clicked');
     await page.getByRole('button', { name: 'Enable Identity Management' }).click();

--- a/scripts/pit/its/cc-identity-management.js
+++ b/scripts/pit/its/cc-identity-management.js
@@ -80,7 +80,7 @@ const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = r
     await takeScreenshot(page, __filename, 'user-created');
 
     log(`Logging in ${app} as ${user} ...\n`);
-    pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
+    pageApp = await createPage(arg.headless, true);
     await waitForServerReady(pageApp, url);
     await takeScreenshot(pageApp, __filename, `app-${app}-loaded`);
     await pageApp.getByLabel('Email').fill(user);

--- a/scripts/pit/its/cc-install-apps.js
+++ b/scripts/pit/its/cc-install-apps.js
@@ -1,6 +1,6 @@
 const { expect} = require('@playwright/test');
 const fs = require('fs');
-const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, run} = require('./test-utils');
+const {log, args, run, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
 
 const arg = args();
 let count = 0;
@@ -22,22 +22,25 @@ async function installApp(app, page) {
     await page.getByLabel('Image', {exact: true}).fill(`k8sdemos/${app}:latest`)
     await page.getByLabel('Application URI', {exact: true}).locator('input[type="text"]').fill(uri)
     if (cert) {
-        log(`Uploading certificate ${cert} for ${app} ...\n`);
+        log(`Uploading certificate ${cert} for ${app}...\n`);
         await page.getByLabel('Upload').click();
         const fileChooserPromise = page.waitForEvent('filechooser');
         await page.getByText('Browse').click();
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles(cert);
-        fileChooserPromise.then(await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click())
+        await takeScreenshot(page, __filename, `form-filled-${app}`);
+        await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click();
     } else {
+        log(`No certificate found for ${app}...\n`);
         log(`No certificate found for ${app}\n`);
         run(`pwd`);
         run(`ls -l`);
         await page.getByLabel('Generate').click();
+        await takeScreenshot(page, __filename, `form-filled-${app}`);
         await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click();
     }
 
-    await takeScreenshot(page, __filename, `form-filled-${app}`);
+    await takeScreenshot(page, __filename, `form-clicked-${app}`);
 
     await page.getByRole('listitem').filter({ hasText: 'Settings'}).click()
 

--- a/scripts/pit/its/cc-install-apps.js
+++ b/scripts/pit/its/cc-install-apps.js
@@ -64,7 +64,7 @@ async function installApp(app, page) {
         await installApp(app, page);
     }
 
-    log(`Waiting for the applications to be available...\n`);
+    log(`Waiting for 2 applications to be available...\n`);
     const selector = 'vaadin-grid-cell-content span[theme="badge success"]';
     await expect(page.locator(selector).nth(0)).toBeVisible({ timeout: 180000 });
     await takeScreenshot(page, __filename, 'app-1-available');

--- a/scripts/pit/its/cc-install-apps.js
+++ b/scripts/pit/its/cc-install-apps.js
@@ -12,8 +12,6 @@ async function installApp(app, page) {
     const cert = [ domain, uri ].map(a => `${a}.pem`).filter( a => fs.existsSync(a))[0]
     console.log(`Installing App: ${app} URI: ${uri} Cert: ${cert}`);
 
-    await takeScreenshot(page, __filename, `page-loaded-${app}`);
-
     await page.getByRole('listitem').filter({ hasText: 'Settings'}).click()
     await page.getByRole('button', {name: 'Deploy'}).click()
     await takeScreenshot(page, __filename, `form-opened-${app}`);
@@ -40,11 +38,8 @@ async function installApp(app, page) {
         await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click();
     }
 
-    await takeScreenshot(page, __filename, `form-clicked-${app}`);
-
     await page.getByRole('listitem').filter({ hasText: 'Settings'}).click()
-
-    await takeScreenshot(page, __filename, `application-created-${app}`);
+    await takeScreenshot(page, __filename, `form-saved-${app}`);
 
     await expect(page.locator('vaadin-grid').getByText(app, { exact: true })).toBeVisible();
     await expect(await page.getByRole('listitem').filter({ hasText: 'Applications'})

--- a/scripts/pit/its/cc-install-apps.js
+++ b/scripts/pit/its/cc-install-apps.js
@@ -1,6 +1,6 @@
 const { expect} = require('@playwright/test');
 const fs = require('fs');
-const {log, args, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
+const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, run} = require('./test-utils');
 
 const arg = args();
 let count = 0;
@@ -22,6 +22,7 @@ async function installApp(app, page) {
     await page.getByLabel('Image', {exact: true}).fill(`k8sdemos/${app}:latest`)
     await page.getByLabel('Application URI', {exact: true}).locator('input[type="text"]').fill(uri)
     if (cert) {
+        log(`Uploading certificate ${cert} for ${app} ...\n`);
         await page.getByLabel('Upload').click();
         const fileChooserPromise = page.waitForEvent('filechooser');
         await page.getByText('Browse').click();
@@ -29,6 +30,9 @@ async function installApp(app, page) {
         await fileChooser.setFiles(cert);
         fileChooserPromise.then(await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click())
     } else {
+        log(`No certificate found for ${app}\n`);
+        run(`pwd`);
+        run(`ls -l`);
         await page.getByLabel('Generate').click();
         await page.locator('.detail-layout').getByRole('button', {name: 'Deploy'}).click();
     }

--- a/scripts/pit/its/cc-install-apps.js
+++ b/scripts/pit/its/cc-install-apps.js
@@ -73,11 +73,17 @@ async function installApp(app, page) {
 
     log(`Waiting for 2 applications to be available...\n`);
     const selector = 'vaadin-grid-cell-content span[theme="badge success"]';
-    await expect(page.locator(selector).nth(0)).toBeVisible({ timeout: 180000 });
+    const startTime = Date.now();
+
+    await expect(page.locator(selector).nth(0)).toBeVisible({ timeout: 280000 });
+    const firstAppTime = (Date.now() - startTime) / 1000;
     await takeScreenshot(page, __filename, 'app-1-available');
-    log(`First application is available\n`);
-    await expect(page.locator(selector).nth(1)).toBeVisible({ timeout: 180000 });
+    log(`First application is available after ${firstAppTime.toFixed(2)} seconds\n`);
+
+    await expect(page.locator(selector).nth(1)).toBeVisible({ timeout: 280000 });
+    const secondAppTime = (Date.now() - startTime) / 1000;
     await takeScreenshot(page, __filename, 'app-2-available');
-    log(`Second application is available\n`);
+    log(`Second application is available after ${secondAppTime.toFixed(2)} seconds\n`);
+
     await closePage(page);
 })();

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -80,9 +80,11 @@ const { assert } = require('console');
     assert(str.includes('app.title=Panaderia'));
     await fs.rmSync(downloadsDir, { recursive: true });
 
-    log(`Testing that preview page: ${previewUrl} is up and running\n`);
+    log(`Starting preview server\n`);
     await page.getByRole('button', { name: 'Start preview' }).click();
     await page.waitForTimeout(5000);
+
+    log(`Testing that preview page: ${previewUrl} is up and running\n`);
     const pagePrev = await createPage(arg.headless, true /* preview pages do not have a valid certificate */);
     await waitForServerReady(pagePrev, previewUrl);
     await takeScreenshot(pagePrev, __filename, 'preview-ready');

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -36,7 +36,7 @@ const { assert } = require('console');
 
     log(`Checking that  ${app} installed in ${url} is running ...\n`);
     // When app is not running, localization cannot be enabled
-    const pageApp = await createPage(arg.headless, true);
+    const pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
     await waitForServerReady(pageApp, url);
     await takeScreenshot(pageApp, __filename, 'app-running');
     await closePage(pageApp);
@@ -82,7 +82,8 @@ const { assert } = require('console');
 
     log(`Testing that preview page: ${previewUrl} is up and running\n`);
     await page.getByRole('button', { name: 'Start preview' }).click();
-    const pagePrev = await createPage(arg.headless, true);
+    await page.waitForTimeout(5000);
+    const pagePrev = await createPage(arg.headless, true /* preview pages do not have a valid certificate */);
     await waitForServerReady(pagePrev, previewUrl);
     await takeScreenshot(pagePrev, __filename, 'preview-ready');
     const text = await pagePrev.getByText(/Password|Dashboard/).textContent();
@@ -94,7 +95,8 @@ const { assert } = require('console');
         await expect(pagePrev.getByRole('button', { name: 'New order' })).toBeVisible();
         await takeScreenshot(pagePrev, __filename, 'preview-loaded');
     }
-    // await expect(pagePrev.getByText('Panaderia', { exact: true })).toBeVisible();
+    //  TODO: bakery is not internationalized
+    //  await expect(pagePrev.getByText('Panaderia', { exact: true })).toBeVisible();
     await closePage(pagePrev);
 
     log('Cleaning up...\n');

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -37,7 +37,7 @@ const { assert } = require('console');
 
     log(`Checking that  ${app} installed in ${url} is running ...\n`);
     // When app is not running, localization cannot be enabled
-    const pageApp = await createPage(arg.headless, arg.ignoreHTTPSErrors);
+    const pageApp = await createPage(arg.headless, true);
     await waitForServerReady(pageApp, url);
     await closePage(pageApp);
     await takeScreenshot(page, __filename, 'app-running');

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -79,7 +79,7 @@ const { assert } = require('console');
     await run(`unzip -d ${downloadsDir} -o ${filePath}`);
     const str = await fs.readFileSync('./downloads/translations.properties', 'utf8');
     assert(str.includes('app.title=Panaderia'));
-    await fs.rmdirSync(downloadsDir, { recursive: true });
+    await fs.rmSync(downloadsDir, { recursive: true });
 
     log(`Testing that preview page: ${previewUrl} is up and running\n`);
     await page.getByRole('button', { name: 'Start preview' }).click();

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -101,7 +101,9 @@ const { assert } = require('console');
     try {
         await page.getByRole('button', { name: 'Stop preview' }).click();
         await page.getByRole('link', { name: 'Settings' }).click();
+        await page.waitForTimeout(2000);
         await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
+        await page.waitForTimeout(2000);
         await page.getByLabel('Localization').uncheck();
         await page.getByRole('button', { name: 'Disable' }).click();
         await page.getByRole('button', { name: 'Update' }).click();

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -99,12 +99,15 @@ const { assert } = require('console');
     await closePage(pagePrev);
 
     log('Cleaning up...\n');
-    await page.getByRole('button', { name: 'Stop preview' }).click();
-    await page.getByRole('link', { name: 'Settings' }).click();
-    await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
-    await page.getByLabel('Localization').uncheck();
-    await page.getByRole('button', { name: 'Disable' }).click();
-    await page.getByRole('button', { name: 'Update' }).click();
-
+    try {
+        await page.getByRole('button', { name: 'Stop preview' }).click();
+        await page.getByRole('link', { name: 'Settings' }).click();
+        await page.locator('vaadin-grid').getByText('bakery-cc', { exact: true }).click();
+        await page.getByLabel('Localization').uncheck();
+        await page.getByRole('button', { name: 'Disable' }).click();
+        await page.getByRole('button', { name: 'Update' }).click();
+    } catch (error) {
+        err(`Error cleaning up: ${error}\n`);
+    }
     await closePage(page);
 })();

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -1,7 +1,6 @@
 const { expect} = require('@playwright/test');
 const fs = require('fs');
-const path = require('path');
-const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, run} = require('./test-utils');
+const {log, err, args, run, createPage, closePage, takeScreenshot, waitForServerReady} = require('./test-utils');
 const { assert } = require('console');
 
 (async () => {

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -1,74 +1,88 @@
-const {chromium} = require('playwright');
-const sleep = ms => new Promise(r => setTimeout(r, ms));
+const { expect} = require('@playwright/test');
+const fs = require('fs');
 const path = require('path');
-const {expect} = require('@playwright/test');
-
-const ADMIN_EMAIL = 'john.doe@admin.com';
-const ADMIN_PASSWORD = 'adminPassword';
-
-let headless = false, host = 'localhost', port = '8000', hub = false;
-process.argv.forEach(a => {
-    if (/^--headless/.test(a)) {
-        headless = true;
-    } else if (/^--ip=/.test(a)) {
-        ip = a.split('=')[1];
-    } else if (/^--port=/.test(a)) {
-        port = a.split('=')[1];
-    }
-});
+const {log, args, createPage, closePage, takeScreenshot, waitForServerReady, run} = require('./test-utils');
+const { assert } = require('console');
 
 (async () => {
-    const browser = await chromium.launch({
-        headless: headless,
-        chromiumSandbox: false
-    });
-    const context = await browser.newContext({ignoreHTTPSErrors: true});
-
-    // Open new page
-    const page = await context.newPage();
-    page.on('console', msg => console.log("> CONSOLE:", (msg.text() + ' - ' + msg.location().url).replace(/\s+/g, ' ')));
-    page.on('pageerror', err => console.log("> PAGEERROR:", ('' + err).replace(/\s+/g, ' ')));
-
-    // Go to http://${host}:${port}/
-    await page.goto(`http://${host}:${port}/`);
-
-    await page.getByLabel('Email').fill(ADMIN_EMAIL)
-    await page.getByLabel('Password', {exact: true}).fill(ADMIN_PASSWORD)
-    await page.getByRole('button', {name: 'Sign In'}).click()
-
-    await page.goto(`http://${host}:${port}/settings/apps/app1`);
-
-    const locOpt = page.getByLabel('Localization').click();
-    if(await !page.getByLabel('Localization').isChecked()){
-        await page.getByLabel('Localization').click({timeout:60000})
+    const arg = args();
+    if (!arg.login) {
+        log(`Skipping the setup of Control center because of missing --email= parameter\n`)
+        process.exit(1);
     }
+    const app = `bakery-cc`;
+    const user = 'admin@vaadin.com';
+    const password = 'admin';
+    const downloadsDir = './downloads';
+    const propsFile = 'translations.properties';
 
-    await page.getByRole('button', {name: 'Update'}).click()
+    const page = await createPage(arg.headless, arg.ignoreHTTPSErrors);
+    await waitForServerReady(page, arg.url);
 
-    await page.goto(`http://${host}:${port}/app/app1/i18n/translations`);
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await takeScreenshot(page, __filename, 'view-loaded');
 
-    await page.getByRole('menuitem').click()
-    await page.getByText('Upload translations').click()
+    log(`Logging in CC as ${arg.login} ${arg.pass}...\n`);
+    await page.getByLabel('Email').fill(arg.login);
+    await page.getByLabel('Password').fill(arg.pass);
+    await page.getByRole('button', {name: 'Sign In'}).click()
+    await takeScreenshot(page, __filename, 'logged-in');
 
+    await page.getByRole('link', { name: 'Settings', }).click();
+    await takeScreenshot(page, __filename, 'settings');
+    const anchorSelectorURL = `//vaadin-grid-cell-content[.//span[normalize-space(text())="${app}"]]//a`;
+    const url = await page.locator(anchorSelectorURL).getAttribute('href');
+    const previewUrl = url.replace(/:\/\//, '://preview.');
+    log(`App: ${app} installed in: ${url} preview: ${previewUrl}\n`);
 
+    await page.locator('vaadin-select vaadin-input-container div').click();
+    await page.getByRole('option', { name: app }).locator('div').nth(2).click();
+    await takeScreenshot(page, __filename, 'selected-app');
+
+    await page.getByRole('link', { name: 'Localization' }).click();
+    await page.getByRole('button', { name: 'Enable Localization' }).click();
+    await takeScreenshot(page, __filename, 'enabled');
+
+    fs.writeFileSync(propsFile, 'app.title=Bakery\n');
+    await page.getByLabel('Manage translations').locator('svg').click();
+    await page.getByText('Upload translations').click();
+    await page.getByLabel('I understand that this will').check();
     const fileChooserPromise = page.waitForEvent('filechooser');
-    await page.getByText('Upload Files...').click();
+    await page.getByRole('button', { name: 'Upload Files...' }).click();
     const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(path.join(__dirname, 'translations.properties'));
-    await page.getByLabel('I understand that this will replace all corresponding data.').check()
-    await page.getByRole('button', {name: 'Replace data'}).click()
+    await fileChooser.setFiles(propsFile);
+    await page.getByRole('button', { name: 'Replace data' }).click();
+    fs.unlinkSync(propsFile);
+    
+    await page.getByText('Bakery', { exact: true }).click();
+    await page.locator('vaadin-text-area.inline textarea').fill('Panaderia');
+    await page.locator('vaadin-grid').getByRole('button').first().click();
 
-    await page.getByText('Hello anonymous!').click();
-    await page.locator('vaadin-grid-cell-content').getByRole('textbox').fill('Test');
+    await page.getByLabel('Manage translations').locator('svg').click();
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByText('Download translations').click();
+    const download = await downloadPromise;
+    const filePath = `${downloadsDir}/${download.suggestedFilename()}`;
+    await download.saveAs(filePath);
 
-    await page.getByText('Say hello').click();
-    await page.locator('vaadin-grid-cell-content').getByRole('textbox').fill('Say bonjour');
-    await page.locator('.confirm-button').click();
+    await run(`unzip -d ${downloadsDir} -o ${filePath}`);
+    const str = await fs.readFileSync('./downloads/translations.properties', 'utf8');
+    assert(str.includes('app.title=Panaderia'));
+    await fs.rmdirSync(downloadsDir, { recursive: true });
 
-    expect(page.getByText('Hello anonymous!')).toBeVisible()
-    expect(page.locator('vaadin-grid-cell-content').filter({ hasText: 'Say bonjour' })).toBeVisible()
+    await page.getByRole('button', { name: 'Start preview' }).click();
 
-    // ---------------------
-    await context.close();
-    await browser.close();
+    log(`Logging in Preview CC as ${user} ${password}...\n`);
+    const pagePrev = await createPage(arg.headless, true);
+    await waitForServerReady(pagePrev, previewUrl);
+    await pagePrev.getByLabel('Email').fill(user);
+    await pagePrev.getByLabel('Password').fill(password);
+    await pagePrev.getByRole('button', {name: 'Sign In'}).click()
+    await takeScreenshot(pagePrev, __filename, 'preview-logged-in');
+    await expect(pagePrev.getByRole('button', { name: 'New order' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Stop preview' }).click();
+
+    await closePage(pagePrev);
+    await closePage(page);
 })();

--- a/scripts/pit/its/cc-localization.js
+++ b/scripts/pit/its/cc-localization.js
@@ -39,8 +39,8 @@ const { assert } = require('console');
     // When app is not running, localization cannot be enabled
     const pageApp = await createPage(arg.headless, true);
     await waitForServerReady(pageApp, url);
+    await takeScreenshot(pageApp, __filename, 'app-running');
     await closePage(pageApp);
-    await takeScreenshot(page, __filename, 'app-running');
 
     log(`Uploading and updating localization keys ...\n`);
     await page.locator('vaadin-select vaadin-input-container div').click();
@@ -85,7 +85,7 @@ const { assert } = require('console');
     await page.getByRole('button', { name: 'Start preview' }).click();
     const pagePrev = await createPage(arg.headless, true);
     await waitForServerReady(pagePrev, previewUrl);
-    await takeScreenshot(page, __filename, 'preview-ready');
+    await takeScreenshot(pagePrev, __filename, 'preview-ready');
     const text = await pagePrev.getByText(/Password|Dashboard/).textContent();
     if (text.includes('Password')) {
         await pagePrev.getByLabel('Email').fill(user);
@@ -93,7 +93,7 @@ const { assert } = require('console');
         await pagePrev.getByRole('button', {name: 'Sign In'}).click()
         await takeScreenshot(pagePrev, __filename, 'preview-logged-in');
         await expect(pagePrev.getByRole('button', { name: 'New order' })).toBeVisible();
-        await takeScreenshot(page, __filename, 'preview-loaded');
+        await takeScreenshot(pagePrev, __filename, 'preview-loaded');
     }
     // await expect(pagePrev.getByText('Panaderia', { exact: true })).toBeVisible();
     await closePage(pagePrev);
@@ -108,6 +108,7 @@ const { assert } = require('console');
         await page.getByRole('button', { name: 'Update' }).click();
     } catch (error) {
         err(`Error cleaning up: ${error}\n`);
+        await takeScreenshot(page, __filename, 'error-cleaning');
     }
     await closePage(page);
 })();

--- a/scripts/pit/its/cc-setup.js
+++ b/scripts/pit/its/cc-setup.js
@@ -33,8 +33,8 @@ const {log, run, args, createPage, closePage, takeScreenshot, waitForServerReady
 
     await takeScreenshot(page, __filename, 'password-changed');
 
-    await page.getByLabel('First Name').fill(arg.login);
-    await page.getByLabel('Last Name').fill(arg.login);
+    await page.getByLabel('First Name').fill(arg.login.split('@')[0]);
+    await page.getByLabel('Last Name').fill(arg.login.split('@')[1]);
     await page.getByRole('button', { name: 'Submit' }).click();
     await takeScreenshot(page, __filename, 'user-configured');
 

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -14,6 +14,10 @@ function log(...args) {
 function out(...args) {
   process.stderr.write(`\x1b[2m\x1b[196m${args}\x1b[0m`);
 }
+function green(...args) {
+  process.stderr.write(`\x1b[2m\x1b[0;32m${args}\x1b[0m`);
+}
+
 function warn(...args) {
   process.stderr.write(`\x1b[2m\x1b[91m${args}\x1b[0m`);
 }
@@ -67,7 +71,7 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const page = await context.newPage();
     page.on('console', msg => {
       const text = `${msg.text()} - ${msg.location().url}`.replace(/\s+/g, ' ');
-      if (!/vaadinPush/.test(text)) out("> CONSOLE:", text, '\n');
+      if (!/vaadinPush|favicon.ico/.test(text)) out("> CONSOLE:", text, '\n');
     });
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));
     page.browser = browser;
@@ -92,7 +96,7 @@ async function takeScreenshot(page, name, descr) {
 // Wait for the server to be ready and to get a valid response
 async function waitForServerReady(page, url, options = {}) {
   const {
-    maxRetries = 20, // Max number of retries
+    maxRetries = 35, // Max number of retries
     retryInterval = 5000 // Interval between retries in milliseconds
   } = options;
 
@@ -103,8 +107,8 @@ async function waitForServerReady(page, url, options = {}) {
       const response = await page.goto(url, {timeout: 120000});
       // Check if the response status is not 503
       if (response && response.status() < 400) {
-        out(` ⏲ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
-        page.waitForTimeout(1500);
+        green(` ✓ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
+        await page.waitForTimeout(1500);
         return response;
       } else {
         out(` ⏲ Attempt ${attempt} Server is not ready yet. ${response.status()}\n`);

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -67,7 +67,7 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const page = await context.newPage();
     page.on('console', msg => {
       const text = `${msg.text()} - ${msg.location().url}`.replace(/\s+/g, ' ');
-      if (!/vaadinPush/.test(msg)) out("> CONSOLE:", text, '\n');
+      if (!/vaadinPush/.test(text)) out("> CONSOLE:", text, '\n');
     });
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));
     page.browser = browser;

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -65,7 +65,10 @@ async function createPage(headless, ignoreHTTPSErrors) {
     });
     const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors, viewport: { width: 1792, height: 970 } });
     const page = await context.newPage();
-    page.on('console', msg => /vaadinPush/.test(msg) || out("> CONSOLE:", (msg.text() + ' - ' + msg.location().url).replace(/\s+/g, ' '), '\n'));
+    page.on('console', msg => {
+      const text = `${msg.text()} - ${msg.location().url}`.replace(/\s+/g, ' ');
+      if (!/vaadinPush/.test(msg)) out("> CONSOLE:", text, '\n');
+    });
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));
     page.browser = browser;
     return page;
@@ -94,6 +97,7 @@ async function waitForServerReady(page, url, options = {}) {
   } = options;
 
   log(`Opening ${url}\n`);
+  page.waitForTimeout(1000);
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       const response = await page.goto(url, {timeout: 120000});

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -82,7 +82,7 @@ async function takeScreenshot(page, name, descr) {
   const scr = path.basename(name);
   const cnt = String(++sscount).padStart(2, "0");
   const file = `${screenshots}/${scr}-${cnt}-${descr}.png`;
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(10000);
   await page.screenshot({ path: file });
   out(` 📸 Screenshot taken: ${file}\n`);
 }

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -14,10 +14,9 @@ function log(...args) {
 function out(...args) {
   process.stderr.write(`\x1b[2m\x1b[196m${args}\x1b[0m`);
 }
-function green(...args) {
-  process.stderr.write(`\x1b[2m\x1b[0;32m${args}\x1b[0m`);
+function ok(...args) {
+  process.stderr.write(`\x1b[2m\x1b[92m${args}\x1b[0m`);
 }
-
 function warn(...args) {
   process.stderr.write(`\x1b[2m\x1b[91m${args}\x1b[0m`);
 }
@@ -108,7 +107,7 @@ async function waitForServerReady(page, url, options = {}) {
       // Check if the response status is not 503
       if (response && response.status() < 400) {
         await page.waitForTimeout(1500);
-        green(` ✓ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
+        ok(` ✓ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
         return response;
       } else {
         out(` ⏲ Attempt ${attempt} Server is not ready yet. ${response.status()}\n`);

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -22,6 +22,7 @@ function warn(...args) {
 }
 function err(...args) {
   process.stderr.write(`\x1b[0;31m${args}\x1b[0m`.split('\n')[0] + '\n');
+  out(args);
 }
 
 const run = async (cmd) => (await promisify(exec)(cmd)).stdout;
@@ -70,7 +71,7 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const page = await context.newPage();
     page.on('console', msg => {
       const text = `${msg.text()} - ${msg.location().url}`.replace(/\s+/g, ' ');
-      if (!/vaadinPush|favicon.ico/.test(text)) out("> CONSOLE:", text, '\n');
+      if (!/vaadinPush|favicon.ico|Autofocus/.test(text)) out("> CONSOLE:", text, '\n');
     });
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));
     page.browser = browser;

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -96,7 +96,7 @@ async function waitForServerReady(page, url, options = {}) {
   log(`Opening ${url}\n`);
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const response = await page.goto(url, {timeou: 120000});
+      const response = await page.goto(url, {timeout: 120000});
       // Check if the response status is not 503
       if (response && response.status() < 400) {
         out(` ⏲ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -61,9 +61,9 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const browser = await chromium.launch({
         headless: headless,
         chromiumSandbox: false,
-        slowMo: 500
+        slowMo: 500,
     });
-    const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors });
+    const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors, viewport: { width: 1920, height: 1080 } });
     const page = await context.newPage();
     page.on('console', msg => out("> CONSOLE:", (msg.text() + ' - ' + msg.location().url).replace(/\s+/g, ' '), '\n'));
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -61,9 +61,10 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const browser = await chromium.launch({
         headless: headless,
         chromiumSandbox: false,
-        slowMo: 500,
+        slowMo: headless ? -1: 500,
+        args: ['--window-position=0,0']
     });
-    const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors, viewport: { width: 1920, height: 1080 } });
+    const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors, viewport: { width: 1792, height: 970 } });
     const page = await context.newPage();
     page.on('console', msg => out("> CONSOLE:", (msg.text() + ' - ' + msg.location().url).replace(/\s+/g, ' '), '\n'));
     page.on('pageerror', e => warn("> JSERROR:", ('' + e).replace(/\s+/g, ' '), '\n'));

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -85,7 +85,7 @@ async function waitForServerReady(page, url, options = {}) {
     try {
       const response = await page.goto(url);
       // Check if the response status is not 503
-      if (response && response.status() !== 503) {
+      if (response && response.status() < 400) {
         log(`Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
         return response;
       } else {

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -21,7 +21,7 @@ function warn(...args) {
   process.stderr.write(`\x1b[2m\x1b[91m${args}\x1b[0m`);
 }
 function err(...args) {
-  process.stderr.write(`\x1b[0;31m${args}\x1b[0m`);
+  process.stderr.write(`\x1b[0;31m${args}\x1b[0m`.split('\n')[0] + '\n');
 }
 
 const run = async (cmd) => (await promisify(exec)(cmd)).stdout;
@@ -87,7 +87,7 @@ async function takeScreenshot(page, name, descr) {
   const scr = path.basename(name);
   const cnt = String(++sscount).padStart(2, "0");
   const file = `${screenshots}/${scr}-${cnt}-${descr}.png`;
-  await page.waitForTimeout(/^win/.test(process.platform) ? 10000: 1500);
+  await page.waitForTimeout(/^win/.test(process.platform) ? 10000 : process.env.GITHUB_ACTIONS ? 5000 : 1500);
   await page.screenshot({ path: file });
   out(` 📸 Screenshot taken: ${file}\n`);
 }

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -65,6 +65,7 @@ async function createPage(headless, ignoreHTTPSErrors) {
     const browser = await chromium.launch({
         headless: headless,
         chromiumSandbox: false,
+        slowMo: 500,
         args: ['--window-position=0,0']
     });
     const context = await browser.newContext({ignoreHTTPSErrors: ignoreHTTPSErrors, viewport: { width: 1792, height: 970 } });

--- a/scripts/pit/its/test-utils.js
+++ b/scripts/pit/its/test-utils.js
@@ -107,8 +107,8 @@ async function waitForServerReady(page, url, options = {}) {
       const response = await page.goto(url, {timeout: 120000});
       // Check if the response status is not 503
       if (response && response.status() < 400) {
-        green(` ✓ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
         await page.waitForTimeout(1500);
+        green(` ✓ Attempt ${attempt} Server is ready and returned a valid response. ${response.status()}\n`);
         return response;
       } else {
         out(` ⏲ Attempt ${attempt} Server is not ready yet. ${response.status()}\n`);

--- a/scripts/pit/lib/lib-args.sh
+++ b/scripts/pit/lib/lib-args.sh
@@ -23,6 +23,7 @@ Use: $0 with the next options:
  --skip-clean      Do not clean maven cache
  --skip-helm       Do not re-install control-center with helm and continue running tests
  --skip-pw         Do not run playwright tests
+ --cluster=name    Run tests in an existing k8s cluster
  --keep-cc         Keep control-center running after tests
  --pnpm            Use pnpm instead of npm to speed up frontend compilation (default npm)
  --vite            Use vite inetad of webpack to speed up frontend compilation (default webpack)
@@ -37,7 +38,7 @@ Use: $0 with the next options:
                    everything after this argument is the function name and arguments passed to the function.
                    you should take care with arguments that contain spaces, they should be quoted twice.
  --help            Show this message
- --starters=list   List of demos or presets separated by comma to run (default: all) valid options:`echo ,$DEFAULT_STARTERS | sed -e 's/,/\n                   · /g'`
+ --starters=list   List of demos or presets separated by comma to run (default: all) valid options:`echo ,$DEFAULT_STARTERS | tr ' ' , | sed -e 's/,/\n                   · /g'`
 EOF
   exit 1
 }
@@ -74,6 +75,7 @@ checkArgs() {
       --skip-dev) NODEV=true;;
       --skip-prod) NOPROD=true;;
       --skip-pw) SKIPPW=true;;
+      --cluster=*) CLUSTER="$arg";;
       --skip-helm) SKIPHELM=true;;
       --keep-cc) KEEPCC=true;;
       --pnpm) PNPM="-Dpnpm.enable=true";;

--- a/scripts/pit/lib/lib-args.sh
+++ b/scripts/pit/lib/lib-args.sh
@@ -21,6 +21,7 @@ Use: $0 with the next options:
  --skip-prod       Skip production validations
  --skip-dev        Skip dev-mode validations
  --skip-clean      Do not clean maven cache
+ --skip-helm       Do not re-install control-center with helm and continue running tests
  --skip-pw         Do not run playwright tests
  --keep-cc         Keep control-center running after tests
  --pnpm            Use pnpm instead of npm to speed up frontend compilation (default npm)
@@ -73,6 +74,7 @@ checkArgs() {
       --skip-dev) NODEV=true;;
       --skip-prod) NOPROD=true;;
       --skip-pw) SKIPPW=true;;
+      --skip-helm) SKIPHELM=true;;
       --keep-cc) KEEPCC=true;;
       --pnpm) PNPM="-Dpnpm.enable=true";;
       --vite) VITE=true;;

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -146,11 +146,12 @@ showTemporaryPassword() {
 ## Run Playwright tests for the control-center
 runPwTests() {
   computeNpm
+  [ -d screenshots.out ] && runCmd "$TEST" "Removing old screenshots" "rm -rf screenshots.out"
   [ -n "$SKIPPW" ] && return 0
   [ -z "$CC_CERT" -o -z "$CC_KEY" ] && NO_TLS=--notls || NO_TLS=""
   for f in $CC_TESTS; do
     runPlaywrightTests "$PIT_SCR_FOLDER/its/$f" "" "prod" "control-center" --url=https://$CC_CONTROL  --login=$CC_EMAIL $NO_TLS || return 1
-    [ "$f" = cc-install-apps.js ] && reloadIngress && ls -l && cat *.pem && checkTls 
+    [ "$f" = cc-install-apps.js ] && reloadIngress
     sleep 3
   done
 }

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -149,7 +149,7 @@ runPwTests() {
   [ -z "$CC_CERT" -o -z "$CC_KEY" ] && NO_TLS=--notls || NO_TLS=""
   for f in $CC_TESTS; do
     runPlaywrightTests "$PIT_SCR_FOLDER/its/$f" "" "prod" "control-center" --url=https://$CC_CONTROL  --login=$CC_EMAIL $NO_TLS || return 1
-    [ "$f" = cc-install-apps.js ] && reloadIngress && checkTls
+    [ "$f" = cc-install-apps.js ] && reloadIngress && ls -l && cat *.pem && checkTls 
     sleep 3
   done
 }

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -19,7 +19,7 @@ CC_CLUSTER=cc-cluster
 CC_NS=control-center
 
 ## UI tests to run after the control-center is installed
-CC_TESTS="cc-setup.js cc-install-apps.js cc-identity-management.js cc-localization.js"
+CC_TESTS=${CC_TESTS:-cc-setup.js cc-install-apps.js cc-identity-management.js cc-localization.js}
 
 checkDockerRunning() {
   if ! docker ps > /dev/null 2>&1; then

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -77,7 +77,7 @@ uninstallCC() {
 }
 
 checkTls() {
-  [ -n "$TEST" ] && return 0
+  [ -n "$TEST" -o -n "$SKIPHELM" ] && return 0
   for i in `kubectl get ingresses -n $CC_NS | grep nginx | awk '{print $1}'`; do
     log "$i"
     H=`kubectl get ingress $i -n $CC_NS -o jsonpath='{.spec.rules[0].host}'`
@@ -90,6 +90,7 @@ checkTls() {
 
 ## Configure secrets for the control-center and the keycloak servers
 installTls() {
+  [ -n "$SKIPHELM" ] && return 0
   [ -z "$CC_KEY" -o -z "$CC_CERT" ] && log "No CC_KEY and CC_CERT provided, skiping TLS installation" && return 0
   [ -n "$CC_FULL" ] && CC_CERT=$CC_FULL
   [ -z "$TEST" ] && log "Installing TLS $CC_TLS for $CC_CONTROL and $CC_AUT" || cmd "## Creating TLS file '$CC_DOMAIN.pem' from envs"

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -19,7 +19,7 @@ CC_CLUSTER=cc-cluster
 CC_NS=control-center
 
 ## UI tests to run after the control-center is installed
-CC_TESTS="cc-setup.js cc-install-apps.js cc-identity-management.js"
+CC_TESTS="cc-setup.js cc-install-apps.js cc-identity-management.js cc-localization.js"
 
 checkDockerRunning() {
   if ! docker ps > /dev/null 2>&1; then

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -175,7 +175,7 @@ setClusterContext() {
 runControlCenter() {
   CLUSTER=${CLUSTER:-$CC_CLUSTER}
 
-  checkCommands docker kubectl helm  || return 1
+  checkCommands docker kubectl helm unzip || return 1
   checkDockerRunning || return 1
 
   ## Start a new kind cluster if needed

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -103,12 +103,13 @@ installTls() {
   [ -n "$SKIPHELM" ] && return 0
   [ -z "$CC_KEY" -o -z "$CC_CERT" ] && log "No CC_KEY and CC_CERT provided, skiping TLS installation" && return 0
   # [ -n "$CC_FULL" ] && CC_CERT="$CC_FULL"
-  [ -z "$TEST" ] && log "Installing TLS $CC_TLS for $CC_CONTROL and $CC_AUT" || cmd "## Creating TLS file '$CC_DOMAIN.pem' from envs"
+  [ -z "$TEST" ] && log "Installing TLS $CC_TLS for $CC_CONTROL and $CC_AUTH" || cmd "## Creating TLS file '$CC_DOMAIN.pem' from envs"
   f1=cc-tls.crt
   f2=cc-tls.key
+  f3=$CC_DOMAIN.pem
   echo -e "$CC_CERT" > $f1 || return 1
   echo -e "$CC_KEY" > $f2 || return 1
-  cat $f1 $f2 > $CC_DOMAIN.pem
+  cat $f1 $f2 > $f3
 
   # remove old secrets if they exist (only needed for testing purposes since secrets are deleted before running the helm chart)
   kubectl get secret $CC_TLS_A -n $CC_NS >/dev/null 2>&1 && kubectl delete secret $CC_TLS_A -n $CC_NS

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -152,7 +152,9 @@ runPwTests() {
   [ -z "$CC_CERT" -o -z "$CC_KEY" ] && NO_TLS=--notls || NO_TLS=""
   for f in $CC_TESTS; do
     runPlaywrightTests "$PIT_SCR_FOLDER/its/$f" "" "prod" "control-center" --url=https://$CC_CONTROL  --login=$CC_EMAIL $NO_TLS || return 1
-    [ "$f" = cc-install-apps.js ] && reloadIngress && checkTls || return 1
+    if [ "$f" = cc-install-apps.js ]; then
+      reloadIngress && checkTls || return 1
+    fi
     sleep 3
   done
 }

--- a/scripts/pit/lib/lib-ccenter.sh
+++ b/scripts/pit/lib/lib-ccenter.sh
@@ -102,7 +102,7 @@ reloadIngress() {
 installTls() {
   [ -n "$SKIPHELM" ] && return 0
   [ -z "$CC_KEY" -o -z "$CC_CERT" ] && log "No CC_KEY and CC_CERT provided, skiping TLS installation" && return 0
-  [ -n "$CC_FULL" ] && CC_CERT="$CC_FULL"
+  # [ -n "$CC_FULL" ] && CC_CERT="$CC_FULL"
   [ -z "$TEST" ] && log "Installing TLS $CC_TLS for $CC_CONTROL and $CC_AUT" || cmd "## Creating TLS file '$CC_DOMAIN.pem' from envs"
   f1=cc-tls.crt
   f2=cc-tls.key

--- a/scripts/pit/lib/lib-k8s-kind.sh
+++ b/scripts/pit/lib/lib-k8s-kind.sh
@@ -45,7 +45,7 @@ setSuid() {
 
   runCmd "$TEST" "Coping $R" "cp $R /tmp/$1" \
     && runCmd "$TEST" "Changing owner to root to: /tmp/$1" "sudo chown root /tmp/$1" \
-    && runCmd "$TEST" "Changing set-uid to: $R" "sudo chmod u+s $R" && return 0
+    && runCmd "$TEST" "Changing set-uid to: $R" "sudo chmod u+s /tmp/$1" && return 0
 }
 
 ##

--- a/scripts/pit/lib/lib-k8s-kind.sh
+++ b/scripts/pit/lib/lib-k8s-kind.sh
@@ -13,7 +13,7 @@ hasSUID() {
 ## Set SUID bit to the command
 # $1: command
 setSuid() {
-  isWindows && return 0
+  isWindows && echo "$1" && return 0
   T=/tmp/$1
   for W in "$T" `which "$1"`; do
     hasSUID "$W" && echo "$W" && return 0

--- a/scripts/pit/lib/lib-k8s-kind.sh
+++ b/scripts/pit/lib/lib-k8s-kind.sh
@@ -1,22 +1,5 @@
 . `dirname $0`/lib/lib-utils.sh
 
-startCloudProvider() {
-   [ -z "$TEST" ] && docker container inspect kind-cloud-provider >/dev/null 2>&1 && log "Docker Kind Cloud Provider already running" && return
-   runCmd "$TEST" "Starting Docker KinD Cloud Provider" \
-    "docker run --quiet --name kind-cloud-provider --rm  -d  \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      rophy/cloud-provider-kind:0.4.0-20241026-r1"
-
-      # --network kind -p 443:443
-}
-
-stopCloudProvider() {
-  docker ps | grep kind-cloud-provider || return 0
-  runCmd "$TEST" "Stoping Docker KinD Cloud Provider" \
-    "docker kill kind-cloud-provider" || return 1
-  docker ps | grep envoyproxy/envoy | awk '{print $1}' | xargs docker kill 2>/dev/null
-}
-
 ## Check that the command has SUID bit set
 # $1: command
 hasSUID() {
@@ -84,7 +67,8 @@ stopForwardIngress() {
 ##
 # $1: cluster name
 # $2: namespace
-createCluster() {
+createKindCluster() {
+  checkCommands kind || return 1
   kind get clusters | grep -q "^$1$" && return 0
   runCmd "$TEST" "Creating KinD cluster: $1" \
    "kind create cluster --name $1" || return 1
@@ -94,15 +78,10 @@ createCluster() {
 
 ##
 # $1: cluster name
-deleteCluster() {
+deleteKindCluster() {
   kind get clusters | grep -q "^$1$" || return 0
   runCmd "$TEST" "Deleting Cluster $1" \
    "kind delete cluster --name $1" || return 1
 }
-
-
-
-
-
 
 

--- a/scripts/pit/lib/lib-k8s-kind.sh
+++ b/scripts/pit/lib/lib-k8s-kind.sh
@@ -43,7 +43,7 @@ setSuid() {
   runCmd "$TEST" "Changing owner to root to: $R" "sudo chown root $R" \
     && runCmd "$TEST" "Changing set-uid to: $R" "sudo chmod u+s $R" && return 0
 
-  runCmd "$TEST" "Coping $R" "cp $R /tmp/$1" \
+  runCmd "$TEST" "Coping $R" "sudo cp $R /tmp/$1" \
     && runCmd "$TEST" "Changing owner to root to: /tmp/$1" "sudo chown root /tmp/$1" \
     && runCmd "$TEST" "Changing set-uid to: $R" "sudo chmod u+s /tmp/$1" && return 0
 }

--- a/scripts/pit/lib/lib-k8s-kind.sh
+++ b/scripts/pit/lib/lib-k8s-kind.sh
@@ -74,7 +74,7 @@ createKindCluster() {
    "kind create cluster --name $1" || return 1
   runCmd "$TEST" "Setting default namespace $2" \
    "kubectl config set-context --current --namespace=$2"
-}
+  }
 
 ##
 # $1: cluster name

--- a/scripts/pit/lib/lib-playwright.sh
+++ b/scripts/pit/lib/lib-playwright.sh
@@ -13,8 +13,7 @@ isInstalledPlaywright() {
 installPlaywright() {
   _pfile="playwright-"`uname`".out"
   _dir=`dirname "$1"`
-  # @playwright/test
-  (cd "$_dir" && runToFile "'${NPM}' install --no-audit @playwright/test" "$_pfile" "$VERBOSE") || return 1
+  (cd "$_dir" && runToFile "$NPM install --no-audit @playwright/test" "$_pfile" "$VERBOSE") || return 1
   (cd "$_dir" && runToFile "npx playwright install chromium" "$_pfile" "$VERBOSE") || return 1
   isLinux && (cd "$_dir" && runToFile "'${NODE}' ./node_modules/.bin/playwright install-deps chromium" "$_pfile" "$VERBOSE") || true
 }
@@ -44,10 +43,10 @@ runPlaywrightTests() {
   PATH=$PATH runToFile "'$NODE' '$_test_file' $_args" "$_pfile" "$VERBOSE" true
   err=$?
   [ -n "$TEST" ] && return 0
-  H=`grep '> CONSOLE:' "$_pfile" | perl -pe 's/(> CONSOLE: Received xhr.*?feat":).*/$1 .../g'`
+  H=`grep ' > CONSOLE:' "$_pfile" | perl -pe 's/(> CONSOLE: Received xhr.*?feat":).*/$1 .../g'`
   H=`echo "$H" | egrep -v 'Atmosphere|Vaadin push loaded|Websocket successfully opened|Websocket closed|404.*favicon.ico'`
   [ -n "$H" ] && [ "$_mode" = "prod" ] && reportError "Console Warnings in $_mode mode $5" "$H" && echo "$H"
-  H=`grep '> JSERROR:' "$_pfile"`
+  H=`grep ' > JSERROR:' "$_pfile"`
   [ -n "$H" ] && reportError "Console Errors in $_msg" "$H" && echo "$H" && return 1
   H=`tail -15 $_pfile`
   [ $err != 0 ] && reportOutErrors "$_ofile" "Error ($err) running Visual-Test ("`basename $_pfile`")" || echo ">>>> PiT: playwright '$_test_file' done" >> $__file

--- a/scripts/pit/lib/lib-utils.sh
+++ b/scripts/pit/lib/lib-utils.sh
@@ -164,7 +164,7 @@ computeGradle() {
 computeNpm() {
   _VNODE=~/.vaadin/node
   _NPMJS=$_VNODE/lib/node_modules/npm/bin/npm-cli.js
-  NPM=`which npm`
+  NPM="'"`which npm`"'"
   NPX=`which npx`
   NODE=`which node`
   [ -x "$_VNODE/bin/node" -a -f "$_NPMJS" ] && export PATH="$_VNODE/bin:$PATH" && NODE="$_VNODE/bin/node" && NPM="'$NODE' '$_NPMJS'"

--- a/scripts/pit/lib/lib-utils.sh
+++ b/scripts/pit/lib/lib-utils.sh
@@ -167,7 +167,7 @@ computeNpm() {
   NPM=`which npm`
   NPX=`which npx`
   NODE=`which node`
-  [ -x "$_VNODE/bin/node" -a -f "$_NPMJS" ] && export PATH="$_VNODE/bin:$PATH" && NODE="$_VNODE/bin/node" && NPM="'$NODE' $_NPMJS"
+  [ -x "$_VNODE/bin/node" -a -f "$_NPMJS" ] && export PATH="$_VNODE/bin:$PATH" && NODE="$_VNODE/bin/node" && NPM="'$NODE' '$_NPMJS'"
 }
 
 ## Run a command, and shows a message explaining it
@@ -717,7 +717,7 @@ NODE=$NODE
 Java version: `java -version 2>&1`
 Node version: `"$NODE" --version`
 NPM=$NPM
-Npm version: `"$NPM" --version`
+Npm version: `eval $NPM --version`
 "
 }
 

--- a/scripts/pit/run.sh
+++ b/scripts/pit/run.sh
@@ -104,6 +104,10 @@ main() {
     if [ $i = control-center ]; then
       mkdir -p tmp/$i && cd tmp/$i
       run runControlCenter $i
+      if [ $? != 0 ]; then
+         kubectl get pods -n $CC_NS
+         ps -feaww | grep kubectl
+      fi
       cd "$pwd"
       continue
     elif expr "$i" : '.*_jdk' >/dev/null; then

--- a/scripts/pit/run.sh
+++ b/scripts/pit/run.sh
@@ -104,10 +104,6 @@ main() {
     if [ $i = control-center ]; then
       mkdir -p tmp/$i && cd tmp/$i
       run runControlCenter $i
-      if [ $? != 0 ]; then
-         kubectl get pods -n $CC_NS
-         ps -feaww | grep kubectl
-      fi
       cd "$pwd"
       continue
     elif expr "$i" : '.*_jdk' >/dev/null; then


### PR DESCRIPTION
In this PR there are many changes, but main are:
- It adds the `--cluster=` option so as kind is not needed if you have a valid cluster.
  for instance you can enable kubernetes in your Docker Desktop and run the script 
  `./scripts/pit/run.sh --starters=control-center --cluster=docker-desktop`
- It fixes and enables visual tests for the `cc-localization.js` test
- It fixes other issues regarding timeouts and elements in UI not yet present
- It fixes certs for added apps

Tips to run the script:
- Docker desktop needs to be installed and running, as well as helm and kind. k9s is recommended if you want to see in a separated how resources in cluster are deployed
- Run the entire script installing a new kind cluster:
```
./scripts/pit/run.sh --starters=control-center
```
- Run script but seeing what happens in browsers
```
./scripts/pit/run.sh --starters=control-center --headed
```
- Keep CC installed in your system so as you can use it later
```
./scripts/pit/run.sh --starters=control-center --keep-cc
```
In order to use the kind cluster you will need to forward port 443 to the cluster with sudo
```
sudo kubectl port-forward -n control-center service/control-center-ingress-nginx-controller 443:443 -n control-center
```
- Run the script but using your local docker desktop cluster
```
./scripts/pit/run.sh --starters=control-center --cluster=docker-desktop
```